### PR TITLE
Update CLI

### DIFF
--- a/db-clone.gemspec
+++ b/db-clone.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'colorize', '~> 0.7'
+  spec.add_dependency 'cli-ui', '~> 1.2.1'
 
   spec.add_development_dependency 'bundler', '~> 1.15'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/db-clone.gemspec
+++ b/db-clone.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'colorize', '~> 0.7'
   spec.add_dependency 'cli-ui', '~> 1.2.1'
 
   spec.add_development_dependency 'bundler', '~> 1.15'

--- a/lib/db/clone.rb
+++ b/lib/db/clone.rb
@@ -1,4 +1,3 @@
-require 'colorize'
 require 'yaml'
 
 require 'db/clone/cmd_builder.rb'

--- a/lib/db/clone/base.rb
+++ b/lib/db/clone/base.rb
@@ -20,34 +20,39 @@ module Db
 
         cmd_builder = CmdBuilder.new src: @db_yml[src_db], dest: @db_yml[dest_db]
 
-        puts "\n  Executing: #{cmd_builder.cmd.light_blue}\n\n"
-        exec cmd_builder.cmd
+        frame("Cloning #{src_db} into #{dest_db}") do
+          unless !invoke_cli || ask_yes_no("Continue?", default_to_yes: dest_db != @default_src)
+            puts fmt("\n{{x}} Cloning canceled.")
+            abort
+          end
+
+          puts fmt("\n  Executing: {{cyan:#{cmd_builder.cmd}}}\n\n")
+          Process.wait spawn(cmd_builder.cmd)
+          puts fmt("\n{{v}} Cloning complete!")
+        end
       end
 
       private
 
       def prompt_for_src_and_dest
-        databases = @db_yml.keys.sort
-        default_src = databases.include?(@default_src) ? @default_src : databases.first
+        frame('Manual DB Selection') do
+          databases = @db_yml.keys
 
-        src_db = prompt 'Which is the source database?', default_src, databases.map{|name| [name, name.yellow]}.to_h
-        puts "Source database = #{src_db.green}"
+          default_src = databases.include?(@default_src) ? @default_src : databases.first
 
-        databases.delete src_db
-        default_dest = src_db != @default_dest && databases.include?(@default_dest) ? @default_dest : databases.first
+          src_db = prompt 'Which is the source database?', default_src, databases.map { |name| [name, fmt("{{reset:#{name}}}")] }.to_h
 
-        dest_db = prompt 'Which is the destination database?', default_dest, databases.map{|name| [name, name.yellow]}.to_h
-        puts "Destination database = #{dest_db.green}"
+          databases.delete src_db
+          default_dest = src_db != @default_dest && databases.include?(@default_dest) ? @default_dest : databases.first
 
-        if dest_db == @default_src
-          proceed = ask_yes_no "#{'WARNING!'.black.on_yellow} You have selected #{@default_src.green} as your destination database, meaning that db-clone will overwrite it with the contents of your #{src_db.green} database. Do you want to proceed anyway?", false
-          unless proceed
-            puts "\nCloning #{'canceled'.red}."
-            abort
+          dest_db = prompt 'Which is the destination database?', default_dest, databases.map {|name| [name, colorize_destination(name)]}.to_h
+
+          if dest_db == @default_src
+            puts fmt("{{bold:{{yellow:WARNING!}} You have selected {{green:#{@default_src}}} as your destination database, meaning that db-clone will overwrite it with the contents of your {{green:#{src_db}}} database.}}")
           end
-        end
 
-        [src_db, dest_db]
+          [src_db, dest_db]
+        end
       end
 
       def default_src_and_dest
@@ -55,6 +60,19 @@ module Db
         raise ArgumentError.new("Configured default destination database, #{@default_dest}, does not exist in #{Db::Clone.database_yml_path}") unless @db_yml[@default_dest]
 
         [@default_src, @default_dest]
+      end
+
+      def colorize_destination(database_name)
+        color = case database_name
+                when @default_src
+                  'red'
+                when @default_dest
+                  'green'
+                else
+                  'yellow'
+                end
+
+        fmt("{{#{color}:#{database_name}}}")
       end
     end
   end

--- a/lib/db/clone/cmd_prompt.rb
+++ b/lib/db/clone/cmd_prompt.rb
@@ -20,7 +20,7 @@ module Db
       end
 
       def prompt question, default, options={}
-        opts = options.except(default)
+        opts = options.reject { |key,| key == default }
         default_option = options[default]
 
         CLI::UI::Prompt.ask(question) do |handler|

--- a/lib/db/clone/cmd_prompt.rb
+++ b/lib/db/clone/cmd_prompt.rb
@@ -1,44 +1,39 @@
+require 'cli/ui'
+
+CLI::UI::StdoutRouter.enable
+
 module Db
   module Clone
     module CmdPrompt
-      # def ask_for_text instruction, default_text=nil
-      #   if default_text
-      #     print "\n#{instruction} [default = \"#{default_text}\"]: "
-      #   else
-      #     print "\n#{instruction}: "
-      #   end
-      #   text = STDIN.gets.chomp.strip
-      #   text = default_text if text.blank? && default_text
-      #   text
-      # end
+      def frame(title)
+        CLI::UI::Frame.open(title) do
+          yield
+        end
+      end
 
-      def ask_yes_no question, default_to_yes=true
-        print "\n#{question} [#{default_to_yes ? 'Yn' : 'yN'}]: "
-        answer = STDIN.gets.chomp.strip.downcase
-        default_to_yes ? !(answer == 'n') : answer == 'y'
+      def ask_yes_no question, default_to_yes: true
+        if default_to_yes
+          CLI::UI.confirm question
+        else
+          CLI::UI.ask(question, options: %w(no yes)) == 'yes'
+        end
       end
 
       def prompt question, default, options={}
-        default_num = nil
-        numbered_opts = options.map.with_index do |opt, idx|
-          default_num = idx+1 if opt[0] == default
-          [idx+1, {ret_key: opt[0], label: opt[1]}]
-        end.to_h
+        opts = options.except(default)
+        default_option = options[default]
 
-        puts "\n"
-        numbered_opts.each{|choice_num, opt| puts "  [#{choice_num.to_s.white}] #{opt[:label]}" }
+        CLI::UI::Prompt.ask(question) do |handler|
+          handler.option(default_option) { default }
 
-        print "\n#{question} [1-#{options.length}, default=#{default_num}]: "
-
-        selection = STDIN.gets.chomp.strip.to_i
-        selection = default_num if selection.zero?
-
-        if numbered_opts.has_key? selection
-          numbered_opts[selection][:ret_key]
-        else
-          puts "#{'Invalid selection:'.red} #{selection}"
-          prompt question, default, options
+          opts.each do |(value, text)|
+            handler.option(text.to_s) { value }
+          end
         end
+      end
+
+      def fmt text
+        CLI::UI.fmt text
       end
     end
   end

--- a/spec/db/clone/base_spec.rb
+++ b/spec/db/clone/base_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe Db::Clone::Base do
 
     @db_clone = Db::Clone::Base.new
 
-    expect(@db_clone).to receive(:exec).once.and_return nil
+    expect(@db_clone).to receive(:spawn).once.and_return nil
+    expect(Process).to receive(:wait).once.and_return nil
     allow(@db_clone).to receive(:puts)
     allow(@db_clone).to receive(:print)
   end
@@ -21,12 +22,12 @@ RSpec.describe Db::Clone::Base do
   end
 
   it 'will clone with prompts' do
-    expect(STDIN).to receive(:gets).and_return('8', '7')
+    expect(STDIN).to receive(:getc).and_return('8', '7', 'y')
     @db_clone.clone! true
   end
 
   it 'will abort if writing to default source' do
-    allow(STDIN).to receive(:gets).and_return('2', '4')
+    allow(STDIN).to receive(:getc).and_return('2', '4', 'n')
     expect(@db_clone).to receive(:abort).once
     @db_clone.clone! true
   end

--- a/spec/db/clone/cmd_prompt_spec.rb
+++ b/spec/db/clone/cmd_prompt_spec.rb
@@ -9,39 +9,31 @@ RSpec.describe Db::Clone::CmdPrompt do
   end
 
   it 'can prompt a yes/no question (and receive an answer of "y")' do
-    allow(STDIN).to receive(:gets) { 'y' }
-    answered_yes = nil
-    expect { answered_yes = @prompter.ask_yes_no 'Do you wish to proceed?' }.to output("\nDo you wish to proceed? [Yn]: ").to_stdout
+    allow(STDIN).to receive(:getc) { 'y' }
+
+    answered_yes = @prompter.ask_yes_no 'Do you wish to proceed?'
     expect(answered_yes).to eq(true)
   end
 
   it 'can prompt a yes/no question (and receive an answer of "n")' do
-    allow(STDIN).to receive(:gets) { 'n' }
-    answered_yes = nil
-    expect { answered_yes = @prompter.ask_yes_no 'Do you wish to proceed?' }.to output("\nDo you wish to proceed? [Yn]: ").to_stdout
+    allow(STDIN).to receive(:getc) { 'n' }
+
+    answered_yes = @prompter.ask_yes_no 'Do you wish to proceed?'
     expect(answered_yes).to eq(false)
   end
 
   it 'can prompt a multiple choice question' do
-    allow(STDIN).to receive(:gets) { '3' }
+    allow(STDIN).to receive(:getc) { '3' }
 
-    expected_prompt = "\n  [\e[1;37m1\e[0m] Thing One\n  [\e[1;37m2\e[0m] Thing Two\n  [\e[1;37m3\e[0m] Thing Three\n\nWhich option? [1-3, default=2]: "
-
-    response = nil
-    expect { response = @prompter.prompt 'Which option?', :second, {first: 'Thing One', second: 'Thing Two', third: 'Thing Three'} }.to output(expected_prompt).to_stdout
-
+    response = @prompter.prompt 'Which option?', :second, {first: 'Thing One', second: 'Thing Two', third: 'Thing Three'}
     expect(response).to eq(:third)
   end
 
   it 'can reprompt a multiple choice question with invalid selection' do
-    # allow(STDIN).to receive(:gets).once { "4" }
-    allow(STDIN).to receive(:gets).and_return('4', '2')
+    # allow(STDIN).to receive(:getc).once { "4" }
+    allow(STDIN).to receive(:getc).and_return('4', '2')
 
-    expected_prompt = "\n  [\e[1;37m1\e[0m] Thing One\n  [\e[1;37m2\e[0m] Thing Two\n  [\e[1;37m3\e[0m] Thing Three\n\nWhich option? [1-3, default=2]: #{'Invalid selection:'.red} 4\n\n  [\e[1;37m1\e[0m] Thing One\n  [\e[1;37m2\e[0m] Thing Two\n  [\e[1;37m3\e[0m] Thing Three\n\nWhich option? [1-3, default=2]: "
-
-    response = nil
-    expect { response = @prompter.prompt 'Which option?', :second, {first: 'Thing One', second: 'Thing Two', third: 'Thing Three'} }.to output(expected_prompt).to_stdout
-
+    response = @prompter.prompt 'Which option?', :first, {first: 'Thing One', second: 'Thing Two', third: 'Thing Three'}
     expect(response).to eq(:second)
   end
 end


### PR DESCRIPTION
This replaces the older style prompts with fancy ones using CLI::UI.  It also removes the colorize dependency since CLI::UI provides colorizing functionality.

This also changes the actual clone from an `exec` to a `spawn` so that we can output a little extra at the end.  This has a side benefit of telling us how long the operation took, since it was wrapped in a frame. 